### PR TITLE
Updated to release candidate of NetMQ, removed context.

### DIFF
--- a/Obvs.NetMQ.Tests.Console.Publisher/App.config
+++ b/Obvs.NetMQ.Tests.Console.Publisher/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    </startup>
+</configuration>

--- a/Obvs.NetMQ.Tests.Console.Publisher/Obvs.NetMQ.Tests.Console.Publisher.csproj
+++ b/Obvs.NetMQ.Tests.Console.Publisher/Obvs.NetMQ.Tests.Console.Publisher.csproj
@@ -33,12 +33,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AsyncIO, Version=0.1.17.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
-      <HintPath>..\packages\AsyncIO.0.1.17.0\lib\net40\AsyncIO.dll</HintPath>
+    <Reference Include="AsyncIO, Version=0.1.18.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
+      <HintPath>..\packages\AsyncIO.0.1.18.0\lib\net40\AsyncIO.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NetMQ, Version=3.3.2.2, Culture=neutral, PublicKeyToken=a6decef4ddc58b3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\NetMQ.3.3.2.2\lib\net40\NetMQ.dll</HintPath>
+      <HintPath>..\packages\NetMQ.3.3.3-rc4\lib\net40\NetMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Obvs.NetMQ.Tests.Console.Publisher/Obvs.NetMQ.Tests.Console.Publisher.csproj
+++ b/Obvs.NetMQ.Tests.Console.Publisher/Obvs.NetMQ.Tests.Console.Publisher.csproj
@@ -1,0 +1,115 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{74835659-2171-44FD-9AF7-14CF8C52A9CA}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Obvs.NetMQ.Tests.Console.Publisher</RootNamespace>
+    <AssemblyName>Obvs.NetMQ.Tests.Console.Publisher</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="AsyncIO, Version=0.1.17.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
+      <HintPath>..\packages\AsyncIO.0.1.17.0\lib\net40\AsyncIO.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NetMQ, Version=3.3.2.2, Culture=neutral, PublicKeyToken=a6decef4ddc58b3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetMQ.3.3.2.2\lib\net40\NetMQ.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Obvs, Version=3.0.0.49, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Obvs.3.0.0.49\lib\net45\Obvs.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Obvs.Serialization.Json, Version=3.0.0.24, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Obvs.Serialization.Json.3.0.0.24\lib\net45\Obvs.Serialization.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Obvs.Serialization.ProtoBuf, Version=3.0.0.24, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Obvs.Serialization.ProtoBuf.3.0.0.24\lib\net45\Obvs.Serialization.ProtoBuf.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Obvs.NetMQ\Obvs.NetMQ.csproj">
+      <Project>{b8256983-f54a-477c-baca-bf9685135983}</Project>
+      <Name>Obvs.NetMQ</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Obvs.NetMQ.Tests.Console.Publisher/Program.cs
+++ b/Obvs.NetMQ.Tests.Console.Publisher/Program.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NetMQ;
+using NUnit.Framework;
+using Obvs.Serialization;
+using Obvs.Serialization.ProtoBuf;
+using Obvs.Types;
+using ProtoBuf;
+
+namespace Obvs.NetMQ.Tests.Console.Publisher
+{
+	class Program
+	{
+		static void Main(string[] args)
+		{
+			int max = 5;
+			CountdownEvent cd = new CountdownEvent(max);
+
+			string endPoint = "tcp://localhost:5557";
+			System.Console.WriteLine("Publishing on {0}\n", endPoint);
+
+			var context = NetMQContext.Create();
+			const string topic = "TestTopicxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+			{
+				var publisher = new MessagePublisher<IMessage>("tcp://localhost:5557",
+					new ProtoBufMessageSerializer(),
+					context,
+					topic);
+
+				for (int i = 0; i < max; i++)
+				{
+					publisher.PublishAsync(new TestMessageWhereTypeIsVeryMuchDefinitionLongerThen32Characters()
+					{
+						Id = i
+					});
+
+					Thread.Sleep(TimeSpan.FromSeconds(0.5));
+					System.Console.WriteLine("Published: {0}", i);
+				}
+			}
+		}
+	}
+
+	[ProtoContract]
+	public class TestMessageWhereTypeIsVeryMuchDefinitionLongerThen32Characters : IMessage
+	{
+		public TestMessageWhereTypeIsVeryMuchDefinitionLongerThen32Characters()
+		{
+
+		}
+
+		[ProtoMember(1)]
+		public int Id { get; set; }
+
+		public override string ToString()
+		{
+			return "TestMessageWhereTypeIsVeryMuchDefinitionLongerThen32Characters-" + Id;
+		}
+	}
+}

--- a/Obvs.NetMQ.Tests.Console.Publisher/Program.cs
+++ b/Obvs.NetMQ.Tests.Console.Publisher/Program.cs
@@ -35,7 +35,7 @@ namespace Obvs.NetMQ.Tests.Console.Publisher
 
 				for (int i = 0; i < max; i++)
 				{
-					publisher.PublishAsync(new Message1()
+					publisher.PublishAsync(new Message1AndItIs32CharactersLongForSureDefinitionForSure()
 					{
 						Id = i
 					});
@@ -51,9 +51,9 @@ namespace Obvs.NetMQ.Tests.Console.Publisher
 	}
 
 	[ProtoContract]
-	public class Message1 : IMessage
+	public class Message1AndItIs32CharactersLongForSureDefinitionForSure : IMessage
 	{
-		public Message1()
+		public Message1AndItIs32CharactersLongForSureDefinitionForSure()
 		{
 
 		}
@@ -63,7 +63,7 @@ namespace Obvs.NetMQ.Tests.Console.Publisher
 
 		public override string ToString()
 		{
-			return "Message1-" + Id;
+			return "Message1AndItIs32CharactersLongForSureDefinitionForSure-" + Id;
 		}
 	}
 }

--- a/Obvs.NetMQ.Tests.Console.Publisher/Program.cs
+++ b/Obvs.NetMQ.Tests.Console.Publisher/Program.cs
@@ -18,7 +18,7 @@ namespace Obvs.NetMQ.Tests.Console.Publisher
 	{
 		static void Main(string[] args)
 		{
-			int max = 5;
+			int max = 50;
 			CountdownEvent cd = new CountdownEvent(max);
 
 			string endPoint = "tcp://localhost:5557";
@@ -35,7 +35,7 @@ namespace Obvs.NetMQ.Tests.Console.Publisher
 
 				for (int i = 0; i < max; i++)
 				{
-					publisher.PublishAsync(new TestMessageWhereTypeIsVeryMuchDefinitionLongerThen32Characters()
+					publisher.PublishAsync(new Message1()
 					{
 						Id = i
 					});
@@ -44,13 +44,16 @@ namespace Obvs.NetMQ.Tests.Console.Publisher
 					System.Console.WriteLine("Published: {0}", i);
 				}
 			}
+
+			System.Console.WriteLine("[finished - any key to continue]");
+			System.Console.ReadKey();
 		}
 	}
 
 	[ProtoContract]
-	public class TestMessageWhereTypeIsVeryMuchDefinitionLongerThen32Characters : IMessage
+	public class Message1 : IMessage
 	{
-		public TestMessageWhereTypeIsVeryMuchDefinitionLongerThen32Characters()
+		public Message1()
 		{
 
 		}
@@ -60,7 +63,7 @@ namespace Obvs.NetMQ.Tests.Console.Publisher
 
 		public override string ToString()
 		{
-			return "TestMessageWhereTypeIsVeryMuchDefinitionLongerThen32Characters-" + Id;
+			return "Message1-" + Id;
 		}
 	}
 }

--- a/Obvs.NetMQ.Tests.Console.Publisher/Program.cs
+++ b/Obvs.NetMQ.Tests.Console.Publisher/Program.cs
@@ -24,13 +24,11 @@ namespace Obvs.NetMQ.Tests.Console.Publisher
 			string endPoint = "tcp://localhost:5557";
 			System.Console.WriteLine("Publishing on {0}\n", endPoint);
 
-			var context = NetMQContext.Create();
 			const string topic = "TestTopicxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 
 			{
 				var publisher = new MessagePublisher<IMessage>("tcp://localhost:5557",
 					new ProtoBufMessageSerializer(),
-					context,
 					topic);
 
 				for (int i = 0; i < max; i++)

--- a/Obvs.NetMQ.Tests.Console.Publisher/Properties/AssemblyInfo.cs
+++ b/Obvs.NetMQ.Tests.Console.Publisher/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Obvs.NetMQ.Tests.Console.Publisher")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Obvs.NetMQ.Tests.Console.Publisher")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("74835659-2171-44fd-9af7-14cf8c52a9ca")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Obvs.NetMQ.Tests.Console.Publisher/packages.config
+++ b/Obvs.NetMQ.Tests.Console.Publisher/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AsyncIO" version="0.1.17.0" targetFramework="net46" />
-  <package id="NetMQ" version="3.3.2.2" targetFramework="net46" />
+  <package id="AsyncIO" version="0.1.18.0" targetFramework="net46" />
+  <package id="NetMQ" version="3.3.3-rc4" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net46" />
   <package id="NUnit" version="2.6.3" targetFramework="net46" />
   <package id="Obvs" version="3.0.0.49" targetFramework="net46" />

--- a/Obvs.NetMQ.Tests.Console.Publisher/packages.config
+++ b/Obvs.NetMQ.Tests.Console.Publisher/packages.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AsyncIO" version="0.1.17.0" targetFramework="net46" />
+  <package id="NetMQ" version="3.3.2.2" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net46" />
+  <package id="NUnit" version="2.6.3" targetFramework="net46" />
+  <package id="Obvs" version="3.0.0.49" targetFramework="net46" />
+  <package id="Obvs.Serialization.Json" version="3.0.0.24" targetFramework="net46" />
+  <package id="Obvs.Serialization.ProtoBuf" version="3.0.0.24" targetFramework="net46" />
+  <package id="protobuf-net" version="2.0.0.668" targetFramework="net46" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net46" />
+</packages>

--- a/Obvs.NetMQ.Tests.Console.Subscriber/App.config
+++ b/Obvs.NetMQ.Tests.Console.Subscriber/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    </startup>
+</configuration>

--- a/Obvs.NetMQ.Tests.Console.Subscriber/App.config
+++ b/Obvs.NetMQ.Tests.Console.Subscriber/App.config
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="AsyncIO" publicKeyToken="44a94435bd6f33f8" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.1.17.0" newVersion="0.1.17.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/Obvs.NetMQ.Tests.Console.Subscriber/Obvs.NetMQ.Tests.Console.Subscriber.csproj
+++ b/Obvs.NetMQ.Tests.Console.Subscriber/Obvs.NetMQ.Tests.Console.Subscriber.csproj
@@ -33,12 +33,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AsyncIO, Version=0.1.17.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
-      <HintPath>..\packages\AsyncIO.0.1.17.0\lib\net40\AsyncIO.dll</HintPath>
+    <Reference Include="AsyncIO, Version=0.1.18.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
+      <HintPath>..\packages\AsyncIO.0.1.18.0\lib\net40\AsyncIO.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NetMQ, Version=3.3.2.2, Culture=neutral, PublicKeyToken=a6decef4ddc58b3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\NetMQ.3.3.2.2\lib\net40\NetMQ.dll</HintPath>
+      <HintPath>..\packages\NetMQ.3.3.3-rc4\lib\net40\NetMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Obvs.NetMQ.Tests.Console.Subscriber/Obvs.NetMQ.Tests.Console.Subscriber.csproj
+++ b/Obvs.NetMQ.Tests.Console.Subscriber/Obvs.NetMQ.Tests.Console.Subscriber.csproj
@@ -1,0 +1,115 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0E91B58C-B139-44DB-AD5E-42D7257D0144}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Obvs.NetMQ.Tests.Console.Subscriber</RootNamespace>
+    <AssemblyName>Obvs.NetMQ.Tests.Console.Subscriber</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="AsyncIO, Version=0.1.17.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
+      <HintPath>..\packages\AsyncIO.0.1.17.0\lib\net40\AsyncIO.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NetMQ, Version=3.3.2.2, Culture=neutral, PublicKeyToken=a6decef4ddc58b3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\NetMQ.3.3.2.2\lib\net40\NetMQ.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Obvs, Version=3.0.0.49, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Obvs.3.0.0.49\lib\net45\Obvs.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Obvs.Serialization.Json, Version=3.0.0.24, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Obvs.Serialization.Json.3.0.0.24\lib\net45\Obvs.Serialization.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Obvs.Serialization.ProtoBuf, Version=3.0.0.24, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Obvs.Serialization.ProtoBuf.3.0.0.24\lib\net45\Obvs.Serialization.ProtoBuf.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Obvs.NetMQ\Obvs.NetMQ.csproj">
+      <Project>{b8256983-f54a-477c-baca-bf9685135983}</Project>
+      <Name>Obvs.NetMQ</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Obvs.NetMQ.Tests.Console.Subscriber/Program.cs
+++ b/Obvs.NetMQ.Tests.Console.Subscriber/Program.cs
@@ -8,7 +8,6 @@ using Obvs.Serialization;
 using Obvs.Serialization.ProtoBuf;
 using Obvs.Types;
 using ProtoBuf;
-using System;
 
 namespace Obvs.NetMQ.Tests.Console.Subscriber
 {
@@ -27,7 +26,7 @@ namespace Obvs.NetMQ.Tests.Console.Subscriber
 				var source = new MessageSource<IMessage>(endPoint,
 					new IMessageDeserializer<IMessage>[]
 					{
-						new ProtoBufMessageDeserializer<Message1>(),
+						new ProtoBufMessageDeserializer<Message1AndItIs32CharactersLongForSureDefinitionForSure>(),
 					},
 					context,
 					topic);
@@ -44,9 +43,9 @@ namespace Obvs.NetMQ.Tests.Console.Subscriber
 	}
 
 	[ProtoContract]
-	public class Message1 : IMessage
+	public class Message1AndItIs32CharactersLongForSureDefinitionForSure : IMessage
 	{
-		public Message1()
+		public Message1AndItIs32CharactersLongForSureDefinitionForSure()
 		{
 
 		}
@@ -56,7 +55,7 @@ namespace Obvs.NetMQ.Tests.Console.Subscriber
 
 		public override string ToString()
 		{
-			return "Message1-" + Id;
+			return "Message1AndItIs32CharactersLongForSureDefinitionForSure-" + Id;
 		}
 	}
 }

--- a/Obvs.NetMQ.Tests.Console.Subscriber/Program.cs
+++ b/Obvs.NetMQ.Tests.Console.Subscriber/Program.cs
@@ -18,7 +18,6 @@ namespace Obvs.NetMQ.Tests.Console.Subscriber
 			string endPoint = "tcp://localhost:5557";
 			System.Console.WriteLine("Listening on {0}\n", endPoint);
 
-			var context = NetMQContext.Create();
 			const string topic = "TestTopicxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 
 			IDisposable sub;
@@ -28,7 +27,6 @@ namespace Obvs.NetMQ.Tests.Console.Subscriber
 					{
 						new ProtoBufMessageDeserializer<Message1AndItIs32CharactersLongForSureDefinitionForSure>(),
 					},
-					context,
 					topic);
 
 				sub = source.Messages.Subscribe(msg =>

--- a/Obvs.NetMQ.Tests.Console.Subscriber/Program.cs
+++ b/Obvs.NetMQ.Tests.Console.Subscriber/Program.cs
@@ -27,7 +27,7 @@ namespace Obvs.NetMQ.Tests.Console.Subscriber
 				var source = new MessageSource<IMessage>(endPoint,
 					new IMessageDeserializer<IMessage>[]
 					{
-						new ProtoBufMessageDeserializer<TestMessageWhereTypeIsVeryMuchDefinitionLongerThen32Characters>(),
+						new ProtoBufMessageDeserializer<Message1>(),
 					},
 					context,
 					topic);
@@ -44,9 +44,9 @@ namespace Obvs.NetMQ.Tests.Console.Subscriber
 	}
 
 	[ProtoContract]
-	public class TestMessageWhereTypeIsVeryMuchDefinitionLongerThen32Characters : IMessage
+	public class Message1 : IMessage
 	{
-		public TestMessageWhereTypeIsVeryMuchDefinitionLongerThen32Characters()
+		public Message1()
 		{
 
 		}
@@ -56,7 +56,7 @@ namespace Obvs.NetMQ.Tests.Console.Subscriber
 
 		public override string ToString()
 		{
-			return "TestMessageWhereTypeIsVeryMuchDefinitionLongerThen32Characters-" + Id;
+			return "Message1-" + Id;
 		}
 	}
 }

--- a/Obvs.NetMQ.Tests.Console.Subscriber/Program.cs
+++ b/Obvs.NetMQ.Tests.Console.Subscriber/Program.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NetMQ;
+using Obvs.Serialization;
+using Obvs.Serialization.ProtoBuf;
+using Obvs.Types;
+using ProtoBuf;
+using System;
+
+namespace Obvs.NetMQ.Tests.Console.Subscriber
+{
+	class Program
+	{
+		static void Main(string[] args)
+		{
+			string endPoint = "tcp://localhost:5557";
+			System.Console.WriteLine("Listening on {0}\n", endPoint);
+
+			var context = NetMQContext.Create();
+			const string topic = "TestTopicxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+			IDisposable sub;
+			{
+				var source = new MessageSource<IMessage>(endPoint,
+					new IMessageDeserializer<IMessage>[]
+					{
+						new ProtoBufMessageDeserializer<TestMessageWhereTypeIsVeryMuchDefinitionLongerThen32Characters>(),
+					},
+					context,
+					topic);
+
+				sub = source.Messages.Subscribe(msg =>
+					{
+						System.Console.WriteLine("Received: " + msg);
+					},
+				   err => System.Console.WriteLine("Error: " + err));
+			}
+
+			System.Console.ReadKey();
+		}
+	}
+
+	[ProtoContract]
+	public class TestMessageWhereTypeIsVeryMuchDefinitionLongerThen32Characters : IMessage
+	{
+		public TestMessageWhereTypeIsVeryMuchDefinitionLongerThen32Characters()
+		{
+
+		}
+
+		[ProtoMember(1)]
+		public int Id { get; set; }
+
+		public override string ToString()
+		{
+			return "TestMessageWhereTypeIsVeryMuchDefinitionLongerThen32Characters-" + Id;
+		}
+	}
+}

--- a/Obvs.NetMQ.Tests.Console.Subscriber/Properties/AssemblyInfo.cs
+++ b/Obvs.NetMQ.Tests.Console.Subscriber/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Obvs.NetMQ.Tests.Console.Subscriber")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Obvs.NetMQ.Tests.Console.Subscriber")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("0e91b58c-b139-44db-ad5e-42d7257d0144")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Obvs.NetMQ.Tests.Console.Subscriber/packages.config
+++ b/Obvs.NetMQ.Tests.Console.Subscriber/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AsyncIO" version="0.1.17.0" targetFramework="net46" />
-  <package id="NetMQ" version="3.3.2.2" targetFramework="net46" />
+  <package id="AsyncIO" version="0.1.18.0" targetFramework="net46" />
+  <package id="NetMQ" version="3.3.3-rc4" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net46" />
   <package id="NUnit" version="2.6.3" targetFramework="net46" />
   <package id="Obvs" version="3.0.0.49" targetFramework="net46" />

--- a/Obvs.NetMQ.Tests.Console.Subscriber/packages.config
+++ b/Obvs.NetMQ.Tests.Console.Subscriber/packages.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AsyncIO" version="0.1.17.0" targetFramework="net46" />
+  <package id="NetMQ" version="3.3.2.2" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net46" />
+  <package id="NUnit" version="2.6.3" targetFramework="net46" />
+  <package id="Obvs" version="3.0.0.49" targetFramework="net46" />
+  <package id="Obvs.Serialization.Json" version="3.0.0.24" targetFramework="net46" />
+  <package id="Obvs.Serialization.ProtoBuf" version="3.0.0.24" targetFramework="net46" />
+  <package id="protobuf-net" version="2.0.0.668" targetFramework="net46" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net46" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net46" />
+</packages>

--- a/Obvs.NetMQ.Tests/Obvs.NetMQ.Tests.csproj
+++ b/Obvs.NetMQ.Tests/Obvs.NetMQ.Tests.csproj
@@ -30,12 +30,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AsyncIO, Version=0.1.17.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
-      <HintPath>..\packages\AsyncIO.0.1.17.0\lib\net40\AsyncIO.dll</HintPath>
+    <Reference Include="AsyncIO, Version=0.1.18.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
+      <HintPath>..\packages\AsyncIO.0.1.18.0\lib\net40\AsyncIO.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NetMQ, Version=3.3.2.2, Culture=neutral, PublicKeyToken=a6decef4ddc58b3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\NetMQ.3.3.2.2\lib\net40\NetMQ.dll</HintPath>
+      <HintPath>..\packages\NetMQ.3.3.3-rc4\lib\net40\NetMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Obvs.NetMQ.Tests/TestPublishSubscribe.cs
+++ b/Obvs.NetMQ.Tests/TestPublishSubscribe.cs
@@ -31,20 +31,18 @@ namespace Obvs.NetMQ.Tests
 
             }, err => Console.WriteLine("Error: " + err));
 
-            var context = NetMQContext.Create();
-
             IMessageSource<IMessage> source = new MessageSource<IMessage>("tcp://localhost:5556",
                 new IMessageDeserializer<IMessage>[]
                 {
                     new JsonMessageDeserializer<TestMessage1>(), 
                     new JsonMessageDeserializer<TestMessage2>()
                 },
-                context, topic);
+                topic);
 
             var sub = source.Messages.Subscribe(observer);
 
             IMessagePublisher<IMessage> publisher = new MessagePublisher<IMessage>("tcp://localhost:5556",
-                new JsonMessageSerializer(), context, topic);
+                new JsonMessageSerializer(), topic);
 
             await publisher.PublishAsync(new TestMessage1 { Id = 1 });
             await publisher.PublishAsync(new TestMessage1 { Id = 2 });
@@ -80,20 +78,18 @@ namespace Obvs.NetMQ.Tests
 
             }, err => Console.WriteLine("Error: " + err));
 
-            var context = NetMQContext.Create();
-
             IMessageSource<IMessage> source = new MessageSource<IMessage>("tcp://localhost:5556",
                 new IMessageDeserializer<IMessage>[]
                 {
                     new ProtoBufMessageDeserializer<TestMessage1>(), 
                     new ProtoBufMessageDeserializer<TestMessage2>()
                 },
-                context, topic);
+                topic);
             
             var sub = source.Messages.Subscribe(observer);
 
             IMessagePublisher<IMessage> publisher = new MessagePublisher<IMessage>("tcp://localhost:5556",
-                new ProtoBufMessageSerializer(), context, topic);
+                new ProtoBufMessageSerializer(), topic);
 
             await publisher.PublishAsync(new TestMessage1 { Id = 1 });
             await publisher.PublishAsync(new TestMessage1 { Id = 2 });
@@ -115,13 +111,12 @@ namespace Obvs.NetMQ.Tests
             source.Dispose();
         }
 
-		[Test]
+		[Test, Explicit]
 	    public void TestMessagesLongerThan32Characters()
 		{
 			int max = 5;
 			CountdownEvent cd = new CountdownEvent(max);
 
-			var context = NetMQContext.Create();
 			const string topic = "TestTopicxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 			IDisposable sub;
 			{
@@ -130,7 +125,6 @@ namespace Obvs.NetMQ.Tests
 				    {
 						new ProtoBufMessageDeserializer<TestMessageWhereTypeIsVeryMuchDefinitionLongerThen32Characters>(), 
 					},
-				    context,
 				    topic);
 
 			     sub = source.Messages.Subscribe(msg =>
@@ -144,7 +138,6 @@ namespace Obvs.NetMQ.Tests
 		    {
 			    var publisher = new MessagePublisher<IMessage>("tcp://localhost:5557",
 				    new ProtoBufMessageSerializer(), 
-				    context,
 				    topic);
 
 			    for (int i = 0; i < max; i++)

--- a/Obvs.NetMQ.Tests/app.config
+++ b/Obvs.NetMQ.Tests/app.config
@@ -1,8 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
-    </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/Obvs.NetMQ.Tests/packages.config
+++ b/Obvs.NetMQ.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AsyncIO" version="0.1.17.0" targetFramework="net45" />
-  <package id="NetMQ" version="3.3.2.2" targetFramework="net45" />
+  <package id="AsyncIO" version="0.1.18.0" targetFramework="net45" />
+  <package id="NetMQ" version="3.3.3-rc4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
   <package id="Obvs" version="3.0.0.49" targetFramework="net45" />

--- a/Obvs.NetMQ.sln
+++ b/Obvs.NetMQ.sln
@@ -1,11 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Obvs.NetMQ", "Obvs.NetMQ\Obvs.NetMQ.csproj", "{B8256983-F54A-477C-BACA-BF9685135983}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Obvs.NetMQ.Tests", "Obvs.NetMQ.Tests\Obvs.NetMQ.Tests.csproj", "{A24FCCF0-448F-4A82-ADAC-17456F6A3A1C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Obvs.NetMQ.Tests.Console.Publisher", "Obvs.NetMQ.Tests.Console.Publisher\Obvs.NetMQ.Tests.Console.Publisher.csproj", "{74835659-2171-44FD-9AF7-14CF8C52A9CA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Obvs.NetMQ.Tests.Console.Subscriber", "Obvs.NetMQ.Tests.Console.Subscriber\Obvs.NetMQ.Tests.Console.Subscriber.csproj", "{0E91B58C-B139-44DB-AD5E-42D7257D0144}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +25,14 @@ Global
 		{A24FCCF0-448F-4A82-ADAC-17456F6A3A1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A24FCCF0-448F-4A82-ADAC-17456F6A3A1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A24FCCF0-448F-4A82-ADAC-17456F6A3A1C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74835659-2171-44FD-9AF7-14CF8C52A9CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74835659-2171-44FD-9AF7-14CF8C52A9CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74835659-2171-44FD-9AF7-14CF8C52A9CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74835659-2171-44FD-9AF7-14CF8C52A9CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0E91B58C-B139-44DB-AD5E-42D7257D0144}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E91B58C-B139-44DB-AD5E-42D7257D0144}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E91B58C-B139-44DB-AD5E-42D7257D0144}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E91B58C-B139-44DB-AD5E-42D7257D0144}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Obvs.NetMQ/Configuration/NetMqServiceEndpointProvider.cs
+++ b/Obvs.NetMQ/Configuration/NetMqServiceEndpointProvider.cs
@@ -19,7 +19,6 @@ namespace Obvs.NetMQ.Configuration
         private readonly IMessageDeserializerFactory _deserializerFactory;
         private readonly Func<Assembly, bool> _assemblyFilter;
         private readonly Func<Type, bool> _typeFilter;
-        private readonly NetMQContext _context = NetMQContext.Create();
         private readonly string _requestAddress;
         private readonly string _responseAddress;
         private readonly string _commandAddress;
@@ -43,20 +42,20 @@ namespace Obvs.NetMQ.Configuration
         public override IServiceEndpoint<TMessage, TCommand, TEvent, TRequest, TResponse> CreateEndpoint()
         {
             return new ServiceEndpoint<TMessage, TCommand, TEvent, TRequest, TResponse>(
-               new MessageSource<TRequest>(_requestAddress, _deserializerFactory.Create<TRequest, TServiceMessage>(_assemblyFilter, _typeFilter), _context, RequestsDestination),
-               new MessageSource<TCommand>(_commandAddress, _deserializerFactory.Create<TCommand, TServiceMessage>(_assemblyFilter, _typeFilter), _context, CommandsDestination),
-               new MessagePublisher<TEvent>(_eventAddress, _serializer, _context, EventsDestination),
-               new MessagePublisher<TResponse>(_responseAddress, _serializer, _context, ResponsesDestination), 
+               new MessageSource<TRequest>(_requestAddress, _deserializerFactory.Create<TRequest, TServiceMessage>(_assemblyFilter, _typeFilter), RequestsDestination),
+               new MessageSource<TCommand>(_commandAddress, _deserializerFactory.Create<TCommand, TServiceMessage>(_assemblyFilter, _typeFilter), CommandsDestination),
+               new MessagePublisher<TEvent>(_eventAddress, _serializer, EventsDestination),
+               new MessagePublisher<TResponse>(_responseAddress, _serializer, ResponsesDestination), 
                typeof(TServiceMessage));
         }
 
         public override IServiceEndpointClient<TMessage, TCommand, TEvent, TRequest, TResponse> CreateEndpointClient()
         {
             return new ServiceEndpointClient<TMessage, TCommand, TEvent, TRequest, TResponse>(
-               new MessageSource<TEvent>(_eventAddress, _deserializerFactory.Create<TEvent, TServiceMessage>(_assemblyFilter, _typeFilter), _context, EventsDestination),
-               new MessageSource<TResponse>(_responseAddress, _deserializerFactory.Create<TResponse, TServiceMessage>(_assemblyFilter, _typeFilter), _context, ResponsesDestination),
-               new MessagePublisher<TRequest>(_requestAddress, _serializer, _context, RequestsDestination),
-               new MessagePublisher<TCommand>(_commandAddress, _serializer, _context, CommandsDestination), 
+               new MessageSource<TEvent>(_eventAddress, _deserializerFactory.Create<TEvent, TServiceMessage>(_assemblyFilter, _typeFilter), EventsDestination),
+               new MessageSource<TResponse>(_responseAddress, _deserializerFactory.Create<TResponse, TServiceMessage>(_assemblyFilter, _typeFilter), ResponsesDestination),
+               new MessagePublisher<TRequest>(_requestAddress, _serializer, RequestsDestination),
+               new MessagePublisher<TCommand>(_commandAddress, _serializer, CommandsDestination), 
                typeof(TServiceMessage));
         }
     }

--- a/Obvs.NetMQ/MessagePublisher.cs
+++ b/Obvs.NetMQ/MessagePublisher.cs
@@ -12,20 +12,18 @@ namespace Obvs.NetMQ
     {
         private readonly string _address;
         private readonly IMessageSerializer _serializer;
-        private readonly NetMQContext _context;
         private readonly string _topic;
         private readonly Lazy<PublisherSocket> _socket;
 
-        public MessagePublisher(string address, IMessageSerializer serializer, NetMQContext context, string topic)
+        public MessagePublisher(string address, IMessageSerializer serializer, string topic)
         {
             _address = address;
             _serializer = serializer;
-            _context = context;
             _topic = topic;
 
             _socket = new Lazy<PublisherSocket>(() =>
             {
-                var socket = _context.CreatePublisherSocket();
+	            var socket = new PublisherSocket(); //; _context.CreatePublisherSocket();
                 socket.Bind(_address);
                 Thread.Sleep(TimeSpan.FromSeconds(1)); // wait for subscribers
                 return socket;

--- a/Obvs.NetMQ/MessagePublisher.cs
+++ b/Obvs.NetMQ/MessagePublisher.cs
@@ -34,6 +34,8 @@ namespace Obvs.NetMQ
 
         private void Publish(TMessage message)
         {
+
+
             _socket.Value.SendToTopic(_topic, message.GetType().Name, _serializer.Serialize(message));
         }
 

--- a/Obvs.NetMQ/MessageSource.cs
+++ b/Obvs.NetMQ/MessageSource.cs
@@ -16,15 +16,13 @@ namespace Obvs.NetMQ
     {
         private readonly string _address;
         private readonly Dictionary<string, IMessageDeserializer<TMessage>> _deserializers;
-        private readonly NetMQContext _context;
         private readonly string _topic;
         private readonly TimeSpan _receiveTimeout = TimeSpan.FromSeconds(1);
 
-        public MessageSource(string address, IEnumerable<IMessageDeserializer<TMessage>> deserializers, NetMQContext context, string topic)
+        public MessageSource(string address, IEnumerable<IMessageDeserializer<TMessage>> deserializers, string topic)
         {
             _address = address;
             _deserializers = deserializers.ToDictionary(d => d.GetTypeName(), d => d);
-            _context = context;
             _topic = topic;
         }
         
@@ -55,7 +53,7 @@ namespace Obvs.NetMQ
         {
             try
             {
-                using (var socket = _context.CreateSubscriberSocket())
+                using (var socket = new SubscriberSocket())
                 {
                     socket.Connect(_address);
                     socket.Subscribe(_topic);

--- a/Obvs.NetMQ/Obvs.NetMQ.csproj
+++ b/Obvs.NetMQ/Obvs.NetMQ.csproj
@@ -30,12 +30,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AsyncIO, Version=0.1.17.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
-      <HintPath>..\packages\AsyncIO.0.1.17.0\lib\net40\AsyncIO.dll</HintPath>
+    <Reference Include="AsyncIO, Version=0.1.18.0, Culture=neutral, PublicKeyToken=44a94435bd6f33f8, processorArchitecture=MSIL">
+      <HintPath>..\packages\AsyncIO.0.1.18.0\lib\net40\AsyncIO.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NetMQ, Version=3.3.2.2, Culture=neutral, PublicKeyToken=a6decef4ddc58b3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\NetMQ.3.3.2.2\lib\net40\NetMQ.dll</HintPath>
+      <HintPath>..\packages\NetMQ.3.3.3-rc4\lib\net40\NetMQ.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Obvs, Version=3.0.0.49, Culture=neutral, processorArchitecture=MSIL">

--- a/Obvs.NetMQ/Properties/AssemblyInfo.cs
+++ b/Obvs.NetMQ/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.3.2.0")]
-[assembly: AssemblyFileVersion("1.3.2.0")]
+[assembly: AssemblyFileVersion("1.3.2.0-rc1")]

--- a/Obvs.NetMQ/packages.config
+++ b/Obvs.NetMQ/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AsyncIO" version="0.1.17.0" targetFramework="net45" />
-  <package id="NetMQ" version="3.3.2.2" targetFramework="net45" />
+  <package id="AsyncIO" version="0.1.18.0" targetFramework="net45" />
+  <package id="NetMQ" version="3.3.3-rc4" targetFramework="net45" />
   <package id="Obvs" version="3.0.0.49" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />


### PR DESCRIPTION
Hi,

First, nice work on this library, I've been studying the code all evening, and it's very well written.

In the very latest version of NetMQ, they have eliminated the context, this now happens automatically behind the scenes. This allows the API to be somewhat simplified.

In this pull request:
- I've added additional tests to ensure that everything works with subscription filter names > 32 characters (this was an issue in older versions of NetMQ).
- Added two console applications to demonstrate publishing and subscribing.
- Upgraded NetMQ to 3.3.3-rc4 (this version seems to work very well for me).
- Removed the need for the context from the API.

I'm not sure if this is appropriate, as it's a change to the API and it uses a NetMQ 3.3.3-rc4, perhaps you can merge it when NetMQ 3.3.3 graduates to stable, or publish this as a beta build on NuGet, as it depends on a beta version of NetMQ. It's entirely up to you.

